### PR TITLE
Add token expiration support

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,7 +42,8 @@ function getTokenFromServer(id, gen=false){
     let url = baseUrlAll+'?printtoken='+id
     if (gen){
         let tokenName = document.getElementById('tokenName').value
-        url = baseUrlAll+'?gen=1&tokenName='+tokenName
+        let expire = document.getElementById('expire').value
+        url = baseUrlAll+'?gen=1&tokenName='+encodeURIComponent(tokenName)+'&expire='+encodeURIComponent(expire)
     }
     document.getElementById(id+'_spinner').classList.remove("d-none")
 


### PR DESCRIPTION
## Summary
- allow passing expiration date when generating tokens
- expose expiration field in token cards
- add expiration input to token generation form
- send expiration date via fetch request

## Testing
- `php -l index.php`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6874cd276b54832b8d3b4883520f89d0