### PR TITLE
Implement shareable token QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Keep this URL for yourself and don't share your username and password.
 
 ``docker exec -d MyVpnHoodServer  bash /app/web/runui.sh``
 
-After running the server you can access the interface through: 
+After running the server you can access the interface through:
 [yourip]:8000/vpnhoodui
+
+## Sharing tokens to mobile
+
+Click the **Share** button next to a token to open a modal dialog. A QR code and
+direct link will be shown so that you can easily open the token page on your
+phone. The QR code encodes a link without revealing the token in the URL.
 
 

--- a/app.js
+++ b/app.js
@@ -76,6 +76,13 @@ function showTokenBox(id,token){
     }
 }
 
+function openShareModal(id){
+    document.getElementById('shareModalQr').src = baseUrlAll+'?shareqr='+id
+    document.getElementById('shareLinkInput').value = baseUrlAll+'?share='+id
+    var modal = new bootstrap.Modal(document.getElementById('shareModal'))
+    modal.show()
+}
+
 function copyText(id) {
     // Get the text field
     var copyText = document.getElementById(id);


### PR DESCRIPTION
## Summary
- generate QR codes linking to a share page instead of embedding tokens
- add Share button and modal with QR code and direct link
- show shared token without login requirement
- document sharing feature in README

## Testing
- `php -l index.php`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6874df5dcd5c832b9eb479a80f377274